### PR TITLE
implement AllenAI doc2json as clowder extractor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,16 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## Unreleased
+
+### Added
+- AllenAI s2orc-doc2json as a clowder extractor. [#3](https://github.com/clowder-framework/text-extractor/issues/3)
+
+### Changed
+
+
+### Fixed
+

--- a/docker-compose.extractors.yml
+++ b/docker-compose.extractors.yml
@@ -1,0 +1,27 @@
+version: '3.5'
+
+# to use the extractors start with
+# docker-compose -f docker-compose.yml -f docker-compose.extractors.yml up
+
+services:
+  # ----------------------------------------------------------------------
+  # EXTRACTORS
+  # ----------------------------------------------------------------------
+
+  # process pdf files
+  grobid:
+    image: grobid/grobid:0.6.2
+    ports:
+      - 8070:8070
+  # extractor text-extractor
+  textextractor:
+    image: textextractor:0.1
+    restart: unless-stopped
+    networks:
+      - clowder
+    depends_on:
+      - grobid
+      - rabbitmq
+      - clowder
+    environment:
+      - RABBITMQ_URI=${RABBITMQ_URI:-amqp://guest:guest@rabbitmq/%2F}


### PR DESCRIPTION
AllenAI s2orc-doc2json is implemented as a clowder extractor.

This uses grobid to convert pdf to tei and then from tei to xml.

Pull docker image "grobid/grobid:0.6.2" .
In the clowder docker-compose.extractors.yml file add the below lines : 

```
  # process pdf files
  grobid:
    image: grobid/grobid:0.6.2
    ports:
      - 8070:8070
    networks:
      - clowder
  
  # extractor text-extractor
  textextractor:
    image: textextractor:0.1
    restart: unless-stopped
    networks: 
      - clowder
    depends_on:
      - grobid
      - rabbitmq
      - clowder
    environment:
      - RABBITMQ_URI=${RABBITMQ_URI:-amqp://guest:guest@rabbitmq/%2F}
 ```