### PR TITLE
6 fix filename json output

### DIFF
--- a/doc2json/grobid2json/grobid/grobid_client.py
+++ b/doc2json/grobid2json/grobid/grobid_client.py
@@ -135,7 +135,6 @@ class GrobidClient(ApiClient):
         # we use ntpath here to be sure it will work on Windows too
         #pdf_file_name = ntpath.basename(pdf_file)
         filename = os.path.join(output, input_filename + '.tei.xml')
-        log.info("TEI filename %s", filename)
         if os.path.isfile(filename):
             return
 

--- a/doc2json/grobid2json/grobid/grobid_client.py
+++ b/doc2json/grobid2json/grobid/grobid_client.py
@@ -120,11 +120,12 @@ class GrobidClient(ApiClient):
 
         if status == 503:
             time.sleep(self.sleep_time)
+            log.info("sleep for process pdf stream")
             return self.process_pdf_stream(pdf_file, pdf_strm, service)
         elif status != 200:
             with open(os.path.join(output, "failed.log"), "a+") as failed:
                 failed.write(pdf_file.strip(".pdf") + "\n")
-            print('Processing failed with error ' + str(status))
+            log.info('Processing failed with error %s', str(status))
             return ""
         else:
             return res.text
@@ -134,19 +135,23 @@ class GrobidClient(ApiClient):
         # we use ntpath here to be sure it will work on Windows too
         #pdf_file_name = ntpath.basename(pdf_file)
         filename = os.path.join(output, os.path.splitext(input_filename)[0] + '.tei.xml')
-        log.info("TEI filename ", filename)
+        log.info("TEI filename %s", filename)
         if os.path.isfile(filename):
             return
 
         log.info("PDF File to process in path %s with name %s", pdf_file, input_filename)
         pdf_strm = open(pdf_file, 'rb').read()
-        tei_text = self.process_pdf_stream(pdf_file, pdf_strm, output, service)
+        tei_text = self.process_pdf_stream(input_filename, pdf_strm, output, service)
 
         # writing TEI file
         if tei_text:
             with io.open(filename, 'w+', encoding='utf8') as tei_file:
                 log.info("writing to tei file %s", tei_file)
                 tei_file.write(tei_text)
+            assert os.path.exists(filename)
+        else:
+            log.error("TEI file error")
+
 
     def process_citation(self, bib_string: str, log_file: str) -> str:
         # process citation raw string and return corresponding dict

--- a/doc2json/grobid2json/grobid/grobid_client.py
+++ b/doc2json/grobid2json/grobid/grobid_client.py
@@ -134,7 +134,7 @@ class GrobidClient(ApiClient):
         # check if TEI file is already produced
         # we use ntpath here to be sure it will work on Windows too
         #pdf_file_name = ntpath.basename(pdf_file)
-        filename = os.path.join(output, os.path.splitext(input_filename)[0] + '.tei.xml')
+        filename = os.path.join(output, input_filename + '.tei.xml')
         log.info("TEI filename %s", filename)
         if os.path.isfile(filename):
             return
@@ -148,9 +148,8 @@ class GrobidClient(ApiClient):
             with io.open(filename, 'w+', encoding='utf8') as tei_file:
                 log.info("writing to tei file %s", tei_file)
                 tei_file.write(tei_text)
-            assert os.path.exists(filename)
         else:
-            log.error("TEI file error")
+            log.error("TEI processing unsuccessful")
 
 
     def process_citation(self, bib_string: str, log_file: str) -> str:

--- a/doc2json/grobid2json/grobid/grobid_client.py
+++ b/doc2json/grobid2json/grobid/grobid_client.py
@@ -134,6 +134,7 @@ class GrobidClient(ApiClient):
         # we use ntpath here to be sure it will work on Windows too
         #pdf_file_name = ntpath.basename(pdf_file)
         filename = os.path.join(output, os.path.splitext(input_filename)[0] + '.tei.xml')
+        log.info("TEI filename ", filename)
         if os.path.isfile(filename):
             return
 

--- a/doc2json/grobid2json/grobid/grobid_client.py
+++ b/doc2json/grobid2json/grobid/grobid_client.py
@@ -129,15 +129,15 @@ class GrobidClient(ApiClient):
         else:
             return res.text
 
-    def process_pdf(self, pdf_file: str, output: str, service: str) -> None:
+    def process_pdf(self, pdf_file: str, input_filename: str, output: str, service: str) -> None:
         # check if TEI file is already produced
         # we use ntpath here to be sure it will work on Windows too
-        pdf_file_name = ntpath.basename(pdf_file)
-        filename = os.path.join(output, os.path.splitext(pdf_file_name)[0] + '.tei.xml')
+        #pdf_file_name = ntpath.basename(pdf_file)
+        filename = os.path.join(output, os.path.splitext(input_filename)[0] + '.tei.xml')
         if os.path.isfile(filename):
             return
 
-        log.info("PDF File to process is %s", pdf_file)
+        log.info("PDF File to process in path %s with name %s", pdf_file, input_filename)
         pdf_strm = open(pdf_file, 'rb').read()
         tei_text = self.process_pdf_stream(pdf_file, pdf_strm, output, service)
 

--- a/doc2json/grobid2json/process_pdf.py
+++ b/doc2json/grobid2json/process_pdf.py
@@ -40,25 +40,28 @@ def process_pdf_stream(input_file: str, sha: str, input_stream: bytes, grobid_co
 
 def process_pdf_file(
         input_file: str,
+        input_filename :str,
         temp_dir: str = BASE_TEMP_DIR,
         output_dir: str = BASE_OUTPUT_DIR,
         grobid_config: Optional[Dict] = None
 ) -> str:
     """
     Process a PDF file and get JSON representation
-    :param input_file:
+    :param input_file: input file resource
+    :param input_filename: input filename resource
     :param temp_dir:
     :param output_dir:
-    :return:
+    :return: json output file
     """
     os.makedirs(temp_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)
 
-    # get paper id as the name of the file
-    paper_id = '.'.join(input_file.split('/')[-1].split('.')[:-1])
-    tei_file = os.path.join(temp_dir, f'{paper_id}.tei.xml')
-    output_file = os.path.join(output_dir, f'{paper_id}.json')
-    log.info("Files %s, %s, %s", paper_id, tei_file, output_file)
+    # check typeof input file
+    log.info("Type of input file %s" %type(input_file))
+    # filenames for tei and json outputs
+    tei_file = os.path.join(temp_dir, f'{input_filename}.tei.xml')
+    output_file = os.path.join(output_dir, f'{input_filename}.json')
+    log.info("Files %s, %s, %s", input_filename, tei_file, output_file)
 
     # check if input file exists and output file doesn't
     if not os.path.exists(input_file):

--- a/doc2json/grobid2json/process_pdf.py
+++ b/doc2json/grobid2json/process_pdf.py
@@ -58,14 +58,13 @@ def process_pdf_file(
 
     # filenames for tei and json outputs
     tei_file = os.path.join(temp_dir, f'{input_filename}.tei.xml')
-    output_file = os.path.join(output_dir, f'{input_filename}.json')
-    log.info("Files %s, %s, %s", input_filename, tei_file, output_file)
+    json_file = os.path.join(output_dir, f'{input_filename}.json')
 
     # check if input file exists and output file doesn't
     if not os.path.exists(input_file):
         raise FileNotFoundError(f"{input_file} doesn't exist")
-    if os.path.exists(output_file):
-        print(f'{output_file} already exists!')
+    if os.path.exists(json_file):
+        print(f'{json_file} already exists!')
 
     # process PDF through Grobid -> TEI.XML
     client = GrobidClient(grobid_config)
@@ -74,15 +73,14 @@ def process_pdf_file(
     client.process_pdf(input_file, input_filename, temp_dir, "processFulltextDocument")
 
     # process TEI.XML -> JSON
-    log.info("TEI File %s", tei_file)
     assert os.path.exists(tei_file)
     paper = convert_tei_xml_file_to_s2orc_json(tei_file)
 
     # write to file
-    with open(output_file, 'w') as outf:
+    with open(json_file, 'w') as outf:
         json.dump(paper.release_json(), outf, indent=4, sort_keys=False)
 
-    return output_file
+    return tei_file, json_file
 
 
 if __name__ == '__main__':

--- a/doc2json/grobid2json/process_pdf.py
+++ b/doc2json/grobid2json/process_pdf.py
@@ -74,7 +74,7 @@ def process_pdf_file(
     client.process_pdf(input_file, input_filename, temp_dir, "processFulltextDocument")
 
     # process TEI.XML -> JSON
-    log.info("TEI File ", tei_file)
+    log.info("TEI File %s", tei_file)
     assert os.path.exists(tei_file)
     paper = convert_tei_xml_file_to_s2orc_json(tei_file)
 

--- a/doc2json/grobid2json/process_pdf.py
+++ b/doc2json/grobid2json/process_pdf.py
@@ -56,8 +56,6 @@ def process_pdf_file(
     os.makedirs(temp_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)
 
-    # check typeof input file
-    log.info("Type of input file %s" %type(input_file))
     # filenames for tei and json outputs
     tei_file = os.path.join(temp_dir, f'{input_filename}.tei.xml')
     output_file = os.path.join(output_dir, f'{input_filename}.json')
@@ -73,7 +71,7 @@ def process_pdf_file(
     client = GrobidClient(grobid_config)
     # TODO: compute PDF hash
     # TODO: add grobid version number to output
-    client.process_pdf(input_file, temp_dir, "processFulltextDocument")
+    client.process_pdf(input_file, input_filename, temp_dir, "processFulltextDocument")
 
     # process TEI.XML -> JSON
     assert os.path.exists(tei_file)

--- a/doc2json/grobid2json/process_pdf.py
+++ b/doc2json/grobid2json/process_pdf.py
@@ -74,6 +74,7 @@ def process_pdf_file(
     client.process_pdf(input_file, input_filename, temp_dir, "processFulltextDocument")
 
     # process TEI.XML -> JSON
+    log.info("TEI File ", tei_file)
     assert os.path.exists(tei_file)
     paper = convert_tei_xml_file_to_s2orc_json(tei_file)
 

--- a/extractor_info.json
+++ b/extractor_info.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
-  "name": "textextractor",
+  "name": "extractors-s2orc-pdf2text",
   "version": "0.1",
   "description": "extracts text from pdf files",
   "author": "Mathew, Minu <minum@illinois.edu>; Lo, Kyle  and Wang, Lucy Lu  and Neumann, Mark  and Kinney, Rodney  and Weld, Daniel",
@@ -9,18 +9,16 @@
   "repository": [
     {
       "repType": "git",
-      "repUrl": "https://github.com/clowder-framework/text-extractor"
+      "repUrl": "https://github.com/clowder-framework/extractors-s2orc-pdf2text"
     }
   ],
   "process": {
     "file": [
-      "application/pdf",
-      "application/*",
-      "text/plain"
+      "application/pdf"
     ]
   },
   "external_services": [],
   "dependencies": [],
   "bibtex": [],
-  "labels": ["Type/Any"]
+  "labels": ["Type/PDF"]
 }

--- a/textextractor.py
+++ b/textextractor.py
@@ -57,7 +57,7 @@ class TextExtractor(Extractor):
         # process pdf file
         start_time = time.time()
         output_file = process_pdf_file(input_file, input_filename, temp_dir, output_dir)
-        log.info("JSON output file " % output_file)
+        log.info("JSON output file %s", output_file)
         runtime = round(time.time() - start_time, 3)
         log.info("runtime: %s seconds " % runtime)
         log.info('done.')

--- a/textextractor.py
+++ b/textextractor.py
@@ -51,19 +51,14 @@ class TextExtractor(Extractor):
 
         temp_dir = BASE_TEMP_DIR
         output_dir = BASE_OUTPUT_DIR
-        # get paper id as the name of the file
-        paper_id = '.'.join(input_filename.split('/')[-1].split('.')[:-1])
-        tei_file = os.path.join(temp_dir, f'{paper_id}.tei.xml')
-        output_file = os.path.join(output_dir, f'{paper_id}.json')
 
         # These process messages will appear in the Clowder UI under Extractions.
         connector.message_process(resource, "Loading contents of file...")
 
         # process pdf file
         start_time = time.time()
-        input_filename = resource["name"]
-        processed_output_file = process_pdf_file(input_file, temp_dir, output_dir)
-        log.info("Processed output file " % processed_output_file)
+        output_file = process_pdf_file(input_file, input_filename, temp_dir, output_dir)
+        log.info("JSON output file " % output_file)
         runtime = round(time.time() - start_time, 3)
         log.info("runtime: %s seconds " % runtime)
         log.info('done.')

--- a/textextractor.py
+++ b/textextractor.py
@@ -56,24 +56,25 @@ class TextExtractor(Extractor):
 
         # process pdf file
         start_time = time.time()
-        output_file = process_pdf_file(input_file, input_filename, temp_dir, output_dir)
-        log.info("JSON output file %s", output_file)
+        output_xml_file, output_json_file = process_pdf_file(input_file, input_filename, temp_dir, output_dir)
+        log.info("Output files : %s, %s", output_xml_file, output_json_file)
+
         runtime = round(time.time() - start_time, 3)
         log.info("runtime: %s seconds " % runtime)
-        log.info('done.')
-        connector.message_process(resource, "Pdf to text conversion finished...")
+        connector.message_process(resource, "Pdf to text conversion finished.")
 
         # clean existing duplicate
         files_in_dataset = pyclowder.datasets.get_file_list(connector, host, secret_key, dataset_id)
         for file in files_in_dataset:
-            if file["filename"] == output_file:
+            if file["filename"] == output_json_file or file["filename"] == output_xml_file:
                 url = '%sapi/files/%s?key=%s' % (host, file["id"], secret_key)
                 connector.delete(url, verify=connector.ssl_verify if connector else True)
-        connector.message_process(resource, "Check for duplicate...")
+        connector.message_process(resource, "Check for duplicate files...")
 
         # upload to clowder
-        pyclowder.files.upload_to_dataset(connector, host, secret_key, dataset_id, output_file)
-        connector.message_process(resource, "Upload processed file to Clowder...")
+        pyclowder.files.upload_to_dataset(connector, host, secret_key, dataset_id, output_json_file)
+        pyclowder.files.upload_to_dataset(connector, host, secret_key, dataset_id, output_xml_file)
+        connector.message_process(resource, "Uploading output files to Clowder...")
 
 
 if __name__ == "__main__":

--- a/textextractor.py
+++ b/textextractor.py
@@ -5,8 +5,6 @@ import time
 import logging
 import json
 import os
-from typing import Optional, Dict
-import logging
 
 from pyclowder.extractors import Extractor
 import pyclowder.files
@@ -42,13 +40,13 @@ class TextExtractor(Extractor):
     def process_message(self, connector, host, secret_key, resource, parameters):
         # Process the file and upload the results
         # uncomment to see the resource
-        log.info("RESOURCE")
-        log.info(resource)
+        # {'type': 'file', 'id': '6435b226e4b02b1506038ec5', 'intermediate_id': '6435b226e4b02b1506038ec5', 'name': 'N18-3011.pdf', 'file_ext': '.pdf', 'parent': {'type': 'dataset', 'id': '64344255e4b0a99d8062e6e0'}, 'local_paths': ['/tmp/tmp2hw6l5ra.pdf']}
+        #log.info(resource)
 
         input_file = resource["local_paths"][0]
         input_file_id = resource['id']
         dataset_id = resource['parent'].get('id')
-        input_filename = resource["name"]
+        input_filename = os.path.splitext(os.path.basename(resource["name"]))[0]
 
         temp_dir = BASE_TEMP_DIR
         output_dir = BASE_OUTPUT_DIR

--- a/textextractor.py
+++ b/textextractor.py
@@ -42,7 +42,8 @@ class TextExtractor(Extractor):
     def process_message(self, connector, host, secret_key, resource, parameters):
         # Process the file and upload the results
         # uncomment to see the resource
-        # print(resource)
+        log.info("RESOURCE")
+        log.info(resource)
 
         input_file = resource["local_paths"][0]
         input_file_id = resource['id']

--- a/textextractor.py
+++ b/textextractor.py
@@ -47,11 +47,12 @@ class TextExtractor(Extractor):
         input_file = resource["local_paths"][0]
         input_file_id = resource['id']
         dataset_id = resource['parent'].get('id')
+        input_filename = resource["name"]
 
         temp_dir = BASE_TEMP_DIR
         output_dir = BASE_OUTPUT_DIR
         # get paper id as the name of the file
-        paper_id = '.'.join(input_file.split('/')[-1].split('.')[:-1])
+        paper_id = '.'.join(input_filename.split('/')[-1].split('.')[:-1])
         tei_file = os.path.join(temp_dir, f'{paper_id}.tei.xml')
         output_file = os.path.join(output_dir, f'{paper_id}.json')
 
@@ -62,6 +63,7 @@ class TextExtractor(Extractor):
         start_time = time.time()
         input_filename = resource["name"]
         processed_output_file = process_pdf_file(input_file, temp_dir, output_dir)
+        log.info("Processed output file " % processed_output_file)
         runtime = round(time.time() - start_time, 3)
         log.info("runtime: %s seconds " % runtime)
         log.info('done.')


### PR DESCRIPTION
The output file names are fixed.
Pyclowder now uploads the TEI.XML file and JSON file outputs as "input_filename".tei.xml and "input_filename".json to the same dataset.
Better logging is done.