### PR TITLE
16 grobid sentence coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - AllenAI s2orc-doc2json as a clowder extractor. [#3](https://github.com/clowder-framework/text-extractor/issues/3)
 - Conversion of json output to text. [#8](https://github.com/clowder-framework/text-extractor/issues/8)
 - Added section headers for text output. [#13](https://github.com/clowder-framework/text-extractor/issues/13)
+- Grobid tei coordinates support. [#16](https://github.com/clowder-framework/text-extractor/issues/16)
 
 ### Changed
 

--- a/extractor_info.json
+++ b/extractor_info.json
@@ -14,11 +14,10 @@
   ],
   "process": {
     "file": [
-      "application/pdf"
+      "manual-submission"
     ]
   },
   "external_services": [],
   "dependencies": [],
-  "bibtex": [],
-  "labels": ["Type/PDF"]
+  "bibtex": []
 }

--- a/extractor_info.json
+++ b/extractor_info.json
@@ -1,7 +1,7 @@
 {
   "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
   "name": "pdf2text-extractor",
-  "version": "0.6",
+  "version": "0.7",
   "description": "Extracts text from pdf files. Creates an xml, json and txt file and uploads to Clowder dataset. Uses Grobid service and AllenAI s2orc-doc2json",
   "author": "Mathew, Minu <minum@illinois.edu>; Lo, Kyle  and Wang, Lucy Lu  and Neumann, Mark  and Kinney, Rodney  and Weld, Daniel",
   "contributors": [],


### PR DESCRIPTION
Grobid process to get sentence coordinates.
Use /api/processFulltextDocument with parameters "teiCoordinates" and "segmentSentences". This gives a TEI XML file with each sentence coordinates and page numbers.
Eg :
```
<facsimile>
		<surface n="1" ulx="0.0" uly="0.0" lrx="595.0" lry="842.0"/>
		<surface n="2" ulx="0.0" uly="0.0" lrx="595.0" lry="842.0"/>
		<surface n="3" ulx="0.0" uly="0.0" lrx="595.0" lry="842.0"/>
		<surface n="4" ulx="0.0" uly="0.0" lrx="595.0" lry="842.0"/>
	</facsimile>
<s coords="2,58.42,766.40,483.20,10.83;2,37.66,777.93,210.02,10.83;2,16.09,791.28,105.28,10.73">each group, number of participants (denominator) included in each analysis and whether the analysis was by original assigned groups No corresponding text</s>
```

`<s coords="1,53.80,194.57,58.71,9.29">` indicates one bounding box with attributes page=1, x=53.80, y=194.57, w=58.71, h=9.29.

`<s coords="1,43.95,722.74,206.93,8.92;1,36.86,733.74,29.95,8.92;1,66.80,733.96,4.08,4.46;1,70.88,733.75,180.00,8.92">`
The above @coords XML attributes introduces 4 bounding boxes to define the area of the sentence (typically because it is on several lines).