### PR TITLE
19 sentence coordinates json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,5 @@ hs_err_pid*
 # Test folder
 **/tests
 **/output
+**/output_dir/
 grobid-0.6.1/

--- a/README.md
+++ b/README.md
@@ -89,3 +89,21 @@ If you use this utility in your research, please cite:
     pages = "4969--4983"
 }
 ```
+
+# Use as a Clowder Extractor
+
+Clowder extractor for converting pdf documents to xml, json and csv format.
+
+## Build extractor image
+
+- Run `docker build . -t hub.ncsa.illinois.edu/clowder/extractors-pdf2text:<version>` to build docker image
+- If you ran into error `[Errno 28] No space left on device:`, try below:
+    - Free more spaces by running `docker system prune --all` 
+    - Increase the Disk image size. You can find the configuration in Docker Desktop
+
+## Publish Image to Private NCSA repo
+- Login first: `docker login hub.ncsa.illinois.edu`
+- Run `docker image push hub.ncsa.illinois.edu/clowder/extractors-pdf2text:<version>`
+
+## Deployment
+- Please refer to Clowder instructions

--- a/doc2txt/grobid2json/grobid/grobid_client.py
+++ b/doc2txt/grobid2json/grobid/grobid_client.py
@@ -22,8 +22,8 @@ require something scalable too, which is not implemented for the moment.
 '''
 
 DEFAULT_GROBID_CONFIG = {
-    "grobid_server": "grobid",
-    #"grobid_server": "172.17.0.0",
+    "grobid_server": "grobid",   # "0.0.0.0" for local  else "grobid"
+    #"grobid_server": "172.17.0.0",  # use the docker IP address if running clowder docker-compose in local
     "grobid_port": "8070",
     "batch_size": 1000,
     "sleep_time": 5,
@@ -256,6 +256,8 @@ class GrobidClient(ApiClient):
 
         res, status = self.post(
             url=the_url,
+            files=files,
+            data=the_data,
             headers={'Accept': 'text/plain'}
         )
         log.info("POST service referenceAnnotations status", status)

--- a/doc2txt/grobid2json/grobid/grobid_client.py
+++ b/doc2txt/grobid2json/grobid/grobid_client.py
@@ -245,7 +245,7 @@ class GrobidClient(ApiClient):
             return res.text
 
 
-    def pdf_reference_annotations(self) -> str:
+    def pdf_reference_annotations(self, pdf_file: str) -> str:
         """
         Return JSON annotations with coordinates in the PDF to be processed
         """
@@ -253,6 +253,52 @@ class GrobidClient(ApiClient):
         the_url = 'http://' + self.grobid_server
         the_url += ":" + self.grobid_port
         the_url += "/api/referenceAnnotations"
+
+        log.info("Processing pdf reference annotations for file in path %s with name %s", pdf_file)
+        pdf_strm = open(pdf_file, 'rb').read()
+
+        # process the stream
+        files = {
+            'input': (
+                pdf_file,
+                pdf_strm,
+                'application/pdf',
+                {'Expires': '0'}
+            )
+        }
+
+        # set the GROBID parameters
+        the_data = {}
+        if self.generate_ids:
+            the_data['generateIDs'] = '1'
+        else:
+            the_data['generateIDs'] = '0'
+
+        if self.consolidate_header:
+            the_data['consolidateHeader'] = '1'
+        else:
+            the_data['consolidateHeader'] = '0'
+
+        if self.consolidate_citations:
+            the_data['consolidateCitations'] = '1'
+        else:
+            the_data['consolidateCitations'] = '0'
+
+        if self.include_raw_affiliations:
+            the_data['includeRawAffiliations'] = '1'
+        else:
+            the_data['includeRawAffiliations'] = '0'
+
+        if self.include_raw_citations:
+            the_data['includeRawCitations'] = '1'
+        else:
+            the_data['includeRawCitations'] = '0'
+
+        if self.teiCoordinates:
+            the_data['teiCoordinates'] = ['ref', 'biblStruct', 'persName', 'head', 'figure', 'formula', 's']
+
+        if self.segmentSentences:
+            the_data['segmentSentences'] = '1'
 
         res, status = self.post(
             url=the_url,

--- a/doc2txt/grobid2json/process_pdf.py
+++ b/doc2txt/grobid2json/process_pdf.py
@@ -8,7 +8,7 @@ from typing import Optional, Dict
 
 from doc2txt.grobid2json.grobid.grobid_client import GrobidClient
 from doc2txt.grobid2json.tei_to_json import convert_tei_xml_file_to_s2orc_json, convert_tei_xml_soup_to_s2orc_json
-from doc2txt.json2txt.json2txt import process_json
+from doc2txt.json2csv.json2csv import process_json2csv
 
 BASE_TEMP_DIR = 'temp'
 BASE_OUTPUT_DIR = 'output'
@@ -51,7 +51,7 @@ def process_pdf_file(
     :param input_filename: input filename resource
     :param temp_dir:
     :param output_dir:
-    :return: xml output file, json output file, txt output file
+    :return: xml output file, json output file, csv output file
     """
     os.makedirs(temp_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)
@@ -59,7 +59,7 @@ def process_pdf_file(
     # filenames for tei and json outputs
     tei_file = os.path.join(temp_dir, f'{input_filename}.tei.xml')
     json_file = os.path.join(output_dir, f'{input_filename}.json')
-    txt_file = os.path.join(output_dir, f'{input_filename}.txt')
+    csv_file = os.path.join(output_dir, f'{input_filename}.csv')
 
     # check if input file exists and output file doesn't
     if not os.path.exists(input_file):
@@ -82,12 +82,10 @@ def process_pdf_file(
         json.dump(paper.release_json(), outf, indent=4, sort_keys=False)
 
     # extract fields from json and write to file
-    output_txt = process_json(json_file)
-    with open(txt_file, 'w') as outfile:
-        for text in output_txt:
-            outfile.write(f"{text}\n")
+    output_df = process_json2csv(input_filename, json_file)
+    output_df.to_csv(csv_file, index=False)
 
-    return tei_file, json_file, txt_file
+    return tei_file, json_file, csv_file
 
 
 if __name__ == '__main__':
@@ -110,7 +108,7 @@ if __name__ == '__main__':
     os.makedirs(output_path, exist_ok=True)
 
     input_filename = os.path.splitext(os.path.basename(input_path))[0]
-    tei_file, json_file, txt_file = process_pdf_file(input_path, input_filename, temp_path, output_path)
+    tei_file, json_file, csv_file = process_pdf_file(input_path, input_filename, temp_path, output_path)
 
     runtime = round(time.time() - start_time, 3)
     print("runtime: %s seconds " % (runtime))

--- a/doc2txt/grobid2json/tei_to_json.py
+++ b/doc2txt/grobid2json/tei_to_json.py
@@ -5,7 +5,6 @@ import sys
 import bs4
 import re
 from bs4 import BeautifulSoup, NavigableString
-import xml.etree.ElementTree as ET
 from typing import List, Dict, Tuple
 
 from doc2txt.s2orc import Paper

--- a/doc2txt/json2csv/json2csv.py
+++ b/doc2txt/json2csv/json2csv.py
@@ -30,7 +30,7 @@ def process_json2csv(input_filename, json_input_file):
     body_data = pdf_json_data["body_text"]
 
     # convert to dataframe
-    tokenized_title = tokenize_sentence(title_text)
+    tokenized_title = [tokenize_sentence(title_text)]
     title_df = pd.DataFrame({'file': input_filename, 'section': 'title', 'sentence': title_text,
                              'prev_sentence': '', 'next_sentence': '',
                              'tokenized_sentence': tokenized_title, 'coordinates': ''})
@@ -65,7 +65,7 @@ def extract_sentences(input_file, data):
             tokenized_sentence = tokenize_sentence(s['sentence'])
             new_row = {'file': input_file, 'section': para['section'], 'sentence': s['sentence'],
                             'prev_sentence': '', 'next_sentence': '',
-                            'tokenized_sentence': tokenized_sentence[0], 'coordinates': s['coords']}
+                            'tokenized_sentence': tokenized_sentence, 'coordinates': s['coords']}
             list_df.append(new_row)
     df = pd.DataFrame(list_df)
 

--- a/doc2txt/json2csv/json2csv.py
+++ b/doc2txt/json2csv/json2csv.py
@@ -1,0 +1,72 @@
+# Convert json to csv
+
+import json
+import logging
+
+import pandas as pd
+from doc2txt.utils.tokenizer import tokenize_sentence
+
+# create log object with current module name
+log = logging.getLogger(__name__)
+
+
+def process_json2csv(input_filename, json_input_file):
+    """
+    Method to convert json file to text.
+    Extracts data from specific json fields and return a list of strings as text
+    Args:
+        input_filename (str): Input filename
+        json_input_file (str): Json input file
+    Returns:
+        df: pandas dataframe
+    """
+    log.info("Extracting information from json file: %s", json_input_file)
+    json_file = open(json_input_file)
+    json_data = json.load(json_file)  # load json object to a dictionary
+
+    title_text = json_data["title"]
+    pdf_json_data = json_data["pdf_parse"]
+    abstract_data = pdf_json_data["abstract"]
+    body_data = pdf_json_data["body_text"]
+
+    # convert to dataframe
+    tokenized_title = tokenize_sentence(title_text)
+    title_df = pd.DataFrame({'file': input_filename, 'section': 'title', 'sentence': title_text,
+                             'prev_sentence': '', 'next_sentence': '',
+                             'tokenized_sentence': tokenized_title, 'coordinates': ''})
+    # Get the text and section from the body
+    abstract_df = extract_sentences(input_filename, abstract_data)
+    body_df = extract_sentences(input_filename, body_data)
+
+    frames = [title_df, abstract_df, body_df]
+    df = pd.concat(frames)
+    # Get the previous sentence
+    df['prev_sentence'] = df['sentence'].shift(1)
+    # Get the next sentence
+    df['next_sentence'] = df['sentence'].shift(-1)
+
+    json_file.close()
+
+    return df
+
+def extract_sentences(input_file, data):
+    """
+    Method to extract text and section from the body
+    Args:
+        input_file (str): Json input file
+        data (dict): Json input data
+    Returns:
+        df: pandas dataframe of sentences and related info.
+    """
+    # [ {text: [ {sentence :str, coords: str} ], cite_spans: List, ref_spans: List, eq_spans: List, section: str}]
+    list_df = []
+    for para in data:
+        for i, s in enumerate(para['text']):
+            tokenized_sentence = tokenize_sentence(s['sentence'])
+            new_row = {'file': input_file, 'section': para['section'], 'sentence': s['sentence'],
+                            'prev_sentence': '', 'next_sentence': '',
+                            'tokenized_sentence': tokenized_sentence[0], 'coordinates': s['coords']}
+            list_df.append(new_row)
+    df = pd.DataFrame(list_df)
+
+    return df if len(list_df) > 0 else pd.DataFrame(columns=['file', 'section', 'sentence', 'prev_sentence', 'next_sentence', 'tokenized_sentence', 'coordinates'])

--- a/doc2txt/json2csv/json2csv.py
+++ b/doc2txt/json2csv/json2csv.py
@@ -60,4 +60,4 @@ def extract_sentences(input_file, data):
             list_df.append(new_row)
     df = pd.DataFrame(list_df)
 
-    return df if len(list_df) > 0 else pd.DataFrame(columns=['file', 'section', 'sentence', 'prev_sentence', 'next_sentence', 'tokenized_sentence', 'coordinates'])
+    return df if len(list_df) > 0 else pd.DataFrame(columns=['file', 'section', 'sentence', 'coordinates'])

--- a/doc2txt/json2csv/json2csv.py
+++ b/doc2txt/json2csv/json2csv.py
@@ -4,7 +4,6 @@ import json
 import logging
 
 import pandas as pd
-from doc2txt.utils.tokenizer import tokenize_sentence
 
 # create log object with current module name
 log = logging.getLogger(__name__)
@@ -30,20 +29,14 @@ def process_json2csv(input_filename, json_input_file):
     body_data = pdf_json_data["body_text"]
 
     # convert to dataframe
-    tokenized_title = [tokenize_sentence(title_text)]
-    title_df = pd.DataFrame({'file': input_filename, 'section': 'title', 'sentence': title_text,
-                             'prev_sentence': '', 'next_sentence': '',
-                             'tokenized_sentence': tokenized_title, 'coordinates': ''})
+    title_data = [input_filename, 'title', title_text, '']
+    title_df = pd.DataFrame([title_data], columns=['file', 'section', 'sentence', 'coordinates'])
     # Get the text and section from the body
     abstract_df = extract_sentences(input_filename, abstract_data)
     body_df = extract_sentences(input_filename, body_data)
 
     frames = [title_df, abstract_df, body_df]
     df = pd.concat(frames)
-    # Get the previous sentence
-    df['prev_sentence'] = df['sentence'].shift(1)
-    # Get the next sentence
-    df['next_sentence'] = df['sentence'].shift(-1)
 
     json_file.close()
 
@@ -62,10 +55,8 @@ def extract_sentences(input_file, data):
     list_df = []
     for para in data:
         for i, s in enumerate(para['text']):
-            tokenized_sentence = tokenize_sentence(s['sentence'])
-            new_row = {'file': input_file, 'section': para['section'], 'sentence': s['sentence'],
-                            'prev_sentence': '', 'next_sentence': '',
-                            'tokenized_sentence': tokenized_sentence, 'coordinates': s['coords']}
+            new_row = {'file': input_file, 'section': para['section'],
+                       'sentence': s['sentence'], 'coordinates': s['coords']}
             list_df.append(new_row)
     df = pd.DataFrame(list_df)
 

--- a/doc2txt/json2txt/json2txt.py
+++ b/doc2txt/json2txt/json2txt.py
@@ -7,7 +7,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def process_json(input_file):
+def process_json2txt(input_file):
     """
     Method to convert json file to text.
     Extracts data from specific json fields and return a list of strings as text

--- a/doc2txt/s2orc.py
+++ b/doc2txt/s2orc.py
@@ -322,7 +322,12 @@ class Paragraph:
     An example json representation (values are examples, not accurate):
 
     {
-        "text": "Formal language techniques BID1 may be used to study FORMULA0 (see REF0)...",
+        "text": [
+            {
+            "sentence": "Formal language techniques BID1 may be used to study FORMULA0 (see REF0)...",
+            "coords": "1,71.66,508.86,218.61,13.15;1,72.00,522.41,162.19,13.15",
+            },
+        ],
         "mention_spans": [
             {
                 "start": 27,

--- a/doc2txt/s2orc.py
+++ b/doc2txt/s2orc.py
@@ -436,7 +436,13 @@ class Paper:
         Get all the body text joined by a newline
         :return:
         """
-        return '\n'.join([para.text for para in self.abstract])
+        # [ {text: [ {sentence :str, coords: str} ], cite_spans: List, ref_spans: List, eq_spans: List, section: List}]
+        abstract_text = ''
+        sentences = ''
+        for para in self.abstract:
+            sentences = ' '.join([sent['sentence'] for sent in para.text])
+        abstract_text += sentences + '\n'
+        return abstract_text
 
     @property
     def raw_body_text(self) -> str:
@@ -444,7 +450,12 @@ class Paper:
         Get all the body text joined by a newline
         :return:
         """
-        return '\n'.join([para.text for para in self.body_text])
+        body_text = ''
+        sentences = ''
+        for para in self.body_text:
+            sentences = ' '.join([sent['sentence'] for sent in para.text])
+        body_text += sentences + '\n'
+        return body_text
 
     def release_json(self, doc_type: str="pdf"):
         """

--- a/doc2txt/utils/bert_config.py
+++ b/doc2txt/utils/bert_config.py
@@ -1,0 +1,76 @@
+import copy
+import json
+import os
+
+from transformers import BertConfig
+
+
+class Config(object):
+    def __init__(self, **kwargs):
+        # bert
+        self.bert_model_name = kwargs.pop('bert_model_name', 'bert-large-cased')
+        self.bert_cache_dir = kwargs.pop('bert_cache_dir', None)
+
+        # files
+        self.train_file = kwargs.pop('train_file', None)
+        self.dev_file = kwargs.pop('dev_file', None)
+        self.test_file = kwargs.pop('test_file', None)
+        self.valid_pattern_path = kwargs.pop('valid_pattern_path', None)
+        self.log_path = kwargs.pop('log_path', None)
+        # training
+        self.accumulate_step = kwargs.pop('accumulate_step', 1)
+        self.batch_size = kwargs.pop('batch_size', 8)
+        self.eval_batch_size = kwargs.pop('eval_batch_size', 4)
+        self.max_epoch = kwargs.pop('max_epoch', 50)
+        self.learning_rate = kwargs.pop('learning_rate', 1e-3)
+        self.bert_learning_rate = kwargs.pop('bert_learning_rate', 1e-5)
+        self.weight_decay = kwargs.pop('weight_decay', 0)
+        self.bert_weight_decay = kwargs.pop('bert_weight_decay', 0)
+        self.guide = kwargs.pop('guide', 1)
+        self.threshold_guide = kwargs.pop('threshold_guide', 0.3)
+        self.num_items = kwargs.pop('num_items', 35)
+
+        self.self_paced = kwargs.pop('self_paced', 1)
+        self.threshold = kwargs.pop('threshold', 0.3)
+        self.growing_factor = kwargs.pop('growing_factor', 1.3)
+
+        self.sen_num = kwargs.pop('sen_num', 0)
+        self.augmentation = kwargs.pop('augmentation', 0)
+
+        self.early_stopping = kwargs.pop('early_stopping', 1)
+        self.lr_scheduler = kwargs.pop('lr_scheduler', 0)
+        # self.metric = kwargs.pop("metric", "F1")
+        # others
+        self.use_gpu = kwargs.pop('use_gpu', True)
+        self.gpu_device = kwargs.pop('gpu_device', -1)
+
+    @classmethod
+    def from_dict(cls, json_object):
+        config = cls()
+        for k, v in json_object.items():
+            setattr(config, k, v)
+        return config
+
+    @classmethod
+    def from_json_file(cls, path):
+        with open(path, 'r', encoding='utf-8') as r:
+            return cls.from_dict(json.load(r))
+
+    def to_dict(self):
+        output = copy.deepcopy(self.__dict__)
+        return output
+
+    def save_config(self, path):
+        """Save a configuration object to a file.
+        :param path (str): path to the output file or its parent directory.
+        """
+        if os.path.isdir(path):
+            path = os.path.join(path, 'config.json')
+        print('Save config to {}'.format(path))
+        with open(path, 'w', encoding='utf-8') as w:
+            w.write(json.dumps(self.to_dict(), indent=2,
+                               sort_keys=True))
+
+    @property
+    def bert_config(self):
+        return BertConfig.from_pretrained(self.bert_model_name, output_all_encoded_layers=False)

--- a/doc2txt/utils/tokenizer.py
+++ b/doc2txt/utils/tokenizer.py
@@ -1,0 +1,23 @@
+# Tokenize sentences using BERT tokenizer
+
+import json
+import logging
+from transformers import BertConfig, BertTokenizer
+from doc2txt.utils.bert_config import Config
+
+import pandas as pd
+
+# create log object with current module name
+log = logging.getLogger(__name__)
+
+def tokenize_sentence(sentence):
+    config = Config()
+    tokenizer = BertTokenizer.from_pretrained(config.bert_model_name, do_lower_case=True)
+    text_ids = tokenizer.encode(sentence,
+                                add_special_tokens=True,
+                                truncation=True,
+                                max_length=128)
+    pad_num = 128 - len(text_ids)
+    attn_mask = [1] * len(text_ids) + [0] * pad_num
+    text_ids = text_ids + [0] * pad_num
+    return [text_ids, attn_mask]

--- a/doc2txt/utils/tokenizer.py
+++ b/doc2txt/utils/tokenizer.py
@@ -3,9 +3,9 @@
 from transformers import BertConfig, BertTokenizer
 from doc2txt.utils.bert_config import Config
 
+config = Config()
 
 def tokenize_sentence(sentence):
-    config = Config()
     tokenizer = BertTokenizer.from_pretrained(config.bert_model_name, do_lower_case=True)
     text_ids = tokenizer.encode(sentence,
                                 add_special_tokens=True,

--- a/doc2txt/utils/tokenizer.py
+++ b/doc2txt/utils/tokenizer.py
@@ -1,14 +1,8 @@
 # Tokenize sentences using BERT tokenizer
 
-import json
-import logging
 from transformers import BertConfig, BertTokenizer
 from doc2txt.utils.bert_config import Config
 
-import pandas as pd
-
-# create log object with current module name
-log = logging.getLogger(__name__)
 
 def tokenize_sentence(sentence):
     config = Config()

--- a/extractor_info.json
+++ b/extractor_info.json
@@ -1,7 +1,7 @@
 {
   "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
   "name": "pdf2text-extractor",
-  "version": "0.7",
+  "version": "0.8",
   "description": "Extracts text from pdf files. Creates an xml, json and txt file and uploads to Clowder dataset. Uses Grobid service and AllenAI s2orc-doc2json",
   "author": "Mathew, Minu <minum@illinois.edu>; Lo, Kyle  and Wang, Lucy Lu  and Neumann, Mark  and Kinney, Rodney  and Weld, Daniel",
   "contributors": [],

--- a/extractor_info.json
+++ b/extractor_info.json
@@ -2,7 +2,7 @@
   "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
   "name": "pdf2text-extractor",
   "version": "0.8",
-  "description": "Extracts text from pdf files. Creates an xml, json and txt file and uploads to Clowder dataset. Uses Grobid service and AllenAI s2orc-doc2json",
+  "description": "Extracts text from pdf files. Creates an xml, json and csv file and uploads to Clowder dataset. Uses Grobid service and AllenAI s2orc-doc2json",
   "author": "Mathew, Minu <minum@illinois.edu>; Lo, Kyle  and Wang, Lucy Lu  and Neumann, Mark  and Kinney, Rodney  and Weld, Daniel",
   "contributors": [],
   "contexts": [{}],

--- a/pdf2text.py
+++ b/pdf2text.py
@@ -53,9 +53,9 @@ class Pdf2TextExtractor(Extractor):
 
         # process pdf file
         start_time = time.time()
-        output_xml_file, output_json_file, output_txt_file = process_pdf_file(input_file, input_filename, temp_dir, output_dir)
+        output_xml_file, output_json_file, output_csv_file = process_pdf_file(input_file, input_filename, temp_dir, output_dir)
 
-        log.info("Output files generated : %s, %s, %s", output_xml_file, output_json_file, output_txt_file)
+        log.info("Output files generated : %s, %s, %s", output_xml_file, output_json_file, output_csv_file)
 
         runtime = round(time.time() - start_time, 3)
         log.info("runtime: %s seconds " % runtime)
@@ -73,13 +73,13 @@ class Pdf2TextExtractor(Extractor):
         connector.message_process(resource, "Uploading output files to Clowder...")
         json_fileid = pyclowder.files.upload_to_dataset(connector, host, secret_key, dataset_id, output_json_file)
         xml_fileid = pyclowder.files.upload_to_dataset(connector, host, secret_key, dataset_id, output_xml_file)
-        txt_fileid = pyclowder.files.upload_to_dataset(connector, host, secret_key, dataset_id, output_txt_file)
+        csv_fileid = pyclowder.files.upload_to_dataset(connector, host, secret_key, dataset_id, output_csv_file)
         # upload metadata to dataset
         extracted_files = [
             {"file_id": input_file_id, "filename": input_filename, "description": "Input pdf file"},
             {"file_id": xml_fileid, "filename": output_xml_file, "description": "TEI XML output file from Grobid"},
             {"file_id": json_fileid, "filename": output_json_file, "description": "JSON output file form Grobid"},
-            {"file_id": txt_fileid, "filename": output_txt_file, "description": "Text output file with extracted text and section headers"}
+            {"file_id": csv_fileid, "filename": output_csv_file, "description": "CSV output file with extracted text,section, and coordinates"}
         ]
         content = {"extractor": "pdf2text-extractor", "extracted_files": extracted_files}
         context = "http://clowder.ncsa.illinois.edu/contexts/metadata.jsonld"

--- a/pdf2text.py
+++ b/pdf2text.py
@@ -89,6 +89,14 @@ class Pdf2TextExtractor(Extractor):
         metadata = {"@context": [context], "created_at": created_at, "agent": agent, "content": [content]}
         pyclowder.datasets.upload_metadata(connector, host, secret_key, dataset_id, metadata)
 
+        # clean up temp_dir and output_dir
+        temp_filelist = [f for f in os.listdir(temp_dir)]
+        for f in temp_filelist:
+            os.remove(os.path.join(temp_dir, f))
+
+        out_filelist = [f for f in os.listdir(output_dir)]
+        for f in out_filelist:
+            os.remove(os.path.join(output_dir, f))
 
 
 if __name__ == "__main__":

--- a/pdf2text.py
+++ b/pdf2text.py
@@ -79,7 +79,7 @@ class Pdf2TextExtractor(Extractor):
             {"file_id": input_file_id, "filename": input_filename, "description": "Input pdf file"},
             {"file_id": xml_fileid, "filename": output_xml_file, "description": "TEI XML output file from Grobid"},
             {"file_id": json_fileid, "filename": output_json_file, "description": "JSON output file form Grobid"},
-            {"file_id": csv_fileid, "filename": output_csv_file, "description": "CSV output file with extracted text,section, and coordinates"}
+            {"file_id": csv_fileid, "filename": output_csv_file, "description": "CSV output file with extracted text, section, and coordinates"}
         ]
         content = {"extractor": "pdf2text-extractor", "extracted_files": extracted_files}
         context = "http://clowder.ncsa.illinois.edu/contexts/metadata.jsonld"

--- a/pdf2text.py
+++ b/pdf2text.py
@@ -83,10 +83,10 @@ class Pdf2TextExtractor(Extractor):
         ]
         content = {"extractor": "pdf2text-extractor", "extracted_files": extracted_files}
         context = "http://clowder.ncsa.illinois.edu/contexts/metadata.jsonld"
-        created_at = datetime.now().strftime("%a %d %B %H:%M:%S UTC %Y")
+        #created_at = datetime.now().strftime("%a %d %B %H:%M:%S UTC %Y")
         user_id = "http://clowder.ncsa.illinois.edu/api/users"  # TODO: can update user id in config
         agent = {"@type": "user", "user_id": user_id}
-        metadata = {"@context": [context], "created_at": created_at, "agent": agent, "content": [content]}
+        metadata = {"@context": [context], "agent": agent, "content": content}
         pyclowder.datasets.upload_metadata(connector, host, secret_key, dataset_id, metadata)
 
         # clean up temp_dir and output_dir

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python-magic==0.4.18
 latex2mathml==2.16.2
 itsdangerous==2.0.1
 pandas==2.0.2
+transformers==4.30.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ lxml
 python-magic==0.4.18
 latex2mathml==2.16.2
 itsdangerous==2.0.1
+pandas==2.0.2


### PR DESCRIPTION
`tei_to_json.py` file is changed to have sentence coordinates included in the json file. Main change is in the `process_paragraph` method, where the return text dictionary is of the format `{text: [ {sentence :str, coords: str} ], cite_spans: List, ref_spans: List, eq_spans: List, section: List}`

The json file is then read and converted to a df with columns `new_row = {'file': input_file, 'section': para['section'], 'sentence': s['sentence'], 'prev_sentence': '', 'next_sentence': '', 'tokenized_sentence': tokenized_sentence, 'coordinates': s['coords']} ` and written to a csv file. 


**Fixes #19 #20**