### PR TITLE
Page dimensions in dataset metadata

### DIFF
--- a/extractor_info.json
+++ b/extractor_info.json
@@ -1,7 +1,7 @@
 {
   "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
   "name": "pdf2text-extractor",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Extracts text from pdf files. Creates an xml, json and csv file and uploads to Clowder dataset. Uses Grobid service and AllenAI s2orc-doc2json",
   "author": "Mathew, Minu <minum@illinois.edu>; Lo, Kyle  and Wang, Lucy Lu  and Neumann, Mark  and Kinney, Rodney  and Weld, Daniel",
   "contributors": [],

--- a/pdf2text.py
+++ b/pdf2text.py
@@ -5,6 +5,7 @@ import time
 import logging
 import os
 from datetime import datetime
+from bs4 import BeautifulSoup
 
 from doc2txt.grobid2json.process_pdf import process_pdf_file
 
@@ -56,10 +57,25 @@ class Pdf2TextExtractor(Extractor):
         output_xml_file, output_json_file, output_csv_file = process_pdf_file(input_file, input_filename, temp_dir, output_dir)
 
         log.info("Output files generated : %s, %s, %s", output_xml_file, output_json_file, output_csv_file)
-
         runtime = round(time.time() - start_time, 3)
         log.info("runtime: %s seconds " % runtime)
-        connector.message_process(resource, "Pdf to text conversion finished.")
+        connector.message_process(resource, "Pdf to text conversion finished.")     
+
+        xml_surface_tags = []
+        page_width = 600  # default page width and height
+        page_height = 800
+        # get page height and width from xml file
+        if output_xml_file:
+            with open(output_xml_file) as f:
+                xml = f.read()
+                soup = BeautifulSoup(xml, 'xml')
+                xml_surface_tags = soup.find_all('surface')
+            pass
+
+        if len(xml_surface_tags) > 0:
+            log.info("Extracting pdf dimensions from xml file")
+            page_width = xml_surface_tags[0]['lrx']
+            page_height = xml_surface_tags[0]['lry']
 
         # clean existing duplicate
         files_in_dataset = pyclowder.datasets.get_file_list(connector, host, secret_key, dataset_id)
@@ -81,7 +97,8 @@ class Pdf2TextExtractor(Extractor):
             {"file_id": json_fileid, "filename": output_json_file, "description": "JSON output file form Grobid"},
             {"file_id": csv_fileid, "filename": output_csv_file, "description": "CSV output file with extracted text, section, and coordinates"}
         ]
-        content = {"extractor": "pdf2text-extractor", "extracted_files": extracted_files}
+        page_dimensions = {"page_width": page_width, "page_height": page_height}
+        content = {"extractor": "pdf2text-extractor", "extracted_files": extracted_files, "page_dimensions": page_dimensions}
         context = "http://clowder.ncsa.illinois.edu/contexts/metadata.jsonld"
         #created_at = datetime.now().strftime("%a %d %B %H:%M:%S UTC %Y")
         user_id = "http://clowder.ncsa.illinois.edu/api/users"  # TODO: can update user id in config


### PR DESCRIPTION
page dimensions added to dataset metadata
Dataset metadata now has the format

```
# upload metadata to dataset
        extracted_files = [
            {"file_id": input_file_id, "filename": input_filename, "description": "Input pdf file"},
            {"file_id": xml_fileid, "filename": output_xml_file, "description": "TEI XML output file from Grobid"},
            {"file_id": json_fileid, "filename": output_json_file, "description": "JSON output file form Grobid"},
            {"file_id": csv_fileid, "filename": output_csv_file, "description": "CSV output file with extracted text, section, and coordinates"}
        ]
        page_dimensions = {"page_width": page_width, "page_height": page_height}
        content = {"extractor": "pdf2text-extractor", "extracted_files": extracted_files, "page_dimensions": page_dimensions}
```