### PR TITLE
Call Clowder v2 or Clowder v1 API depending on ENV variable CLOWDER_API_VERSION

### DIFF
--- a/extractor_info.json
+++ b/extractor_info.json
@@ -1,7 +1,7 @@
 {
   "@context": "http://clowder.ncsa.illinois.edu/contexts/extractors.jsonld",
   "name": "pdf2text-extractor",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "description": "Extracts text from pdf files. Creates an xml, json and csv file and uploads to Clowder dataset. Uses Grobid service and AllenAI s2orc-doc2json",
   "author": "Mathew, Minu <minum@illinois.edu>; Lo, Kyle  and Wang, Lucy Lu  and Neumann, Mark  and Kinney, Rodney  and Weld, Daniel",
   "contributors": [],

--- a/pdf2text.py
+++ b/pdf2text.py
@@ -102,14 +102,9 @@ class Pdf2TextExtractor(Extractor):
         connector.message_process(resource, "Check for duplicate files...")
         files_in_dataset = pyclowder.datasets.get_file_list(connector, host, secret_key, dataset_id)
         for file in files_in_dataset:
-            if CLOWDER_API_VERSION == 'v2':
-                if file["name"] == output_json_file or file["name"] == output_xml_file:
-                    url = '%s%s/files/%s?key=%s' % (host, CLOWDER_API_PATH, file["id"], secret_key)
-                    connector.delete(url, verify=connector.ssl_verify if connector else True)
-            else:
-                if file["filename"] == output_json_file or file["filename"] == output_xml_file:
-                    url = '%s%s/files/%s?key=%s' % (host, CLOWDER_API_PATH, file["id"], secret_key)
-                    connector.delete(url, verify=connector.ssl_verify if connector else True)
+            filename_key = "name" if CLOWDER_API_VERSION == 'v2' else "filename"
+            if file.get(filename_key) in [output_json_file, output_xml_file]:
+                pyclowder.files.delete(connector, host, secret_key, file["id"])
 
         # upload to clowder
         connector.message_process(resource, "Uploading output files to Clowder...")

--- a/pdf2text.py
+++ b/pdf2text.py
@@ -26,6 +26,20 @@ BASE_TEMP_DIR = 'temp'
 BASE_OUTPUT_DIR = 'output'
 BASE_LOG_DIR = 'log'
 
+def clowder_context_url():
+    """JSON-LD context URL for metadata. Override via CLOWDER_CONTEXT_URL env."""
+    return os.environ.get(
+        'CLOWDER_CONTEXT_URL',
+        'http://clowder.ncsa.illinois.edu/contexts/metadata.jsonld'
+    )
+
+def clowder_users_url():
+    """Clowder users API URL for metadata agent. Override via CLOWDER_USERS_URL env."""
+    return os.environ.get(
+        'CLOWDER_USERS_URL',
+        'http://clowder.ncsa.illinois.edu/api/users'
+    )
+
 
 class Pdf2TextExtractor(Extractor):
     def __init__(self):
@@ -111,9 +125,9 @@ class Pdf2TextExtractor(Extractor):
         ]
         page_dimensions = {"width": page_width, "height": page_height}
         content = {"extractor": "pdf2text-extractor", "extracted_files": extracted_files, "page_dimensions": page_dimensions}
-        context = "http://clowder.ncsa.illinois.edu/contexts/metadata.jsonld"
+        context = clowder_context_url()
+        user_id = clowder_users_url()  # TODO: can update user id in config
         #created_at = datetime.now().strftime("%a %d %B %H:%M:%S UTC %Y")
-        user_id = "http://clowder.ncsa.illinois.edu/api/users"  # TODO: can update user id in config
         agent = {"@type": "user", "user_id": user_id}
         metadata = {"@context": [context], "agent": agent, "content": content}
         pyclowder.datasets.upload_metadata(connector, host, secret_key, dataset_id, metadata)

--- a/pdf2text.py
+++ b/pdf2text.py
@@ -4,10 +4,17 @@
 import time
 import logging
 import os
+import json
 from datetime import datetime
 from bs4 import BeautifulSoup
 
+import requests
 from doc2txt.grobid2json.process_pdf import process_pdf_file
+
+# Use api/v2 when CLOWDER_API_VERSION=v2 (Clowder2)
+# Also supports CLOWDER_VERSION=2 from clowder2 docker-compose
+CLOWDER_API_VERSION = os.environ.get('CLOWDER_API_VERSION') or ('v2' if os.environ.get('CLOWDER_VERSION') == '2' else 'v1')
+CLOWDER_API_PATH = 'api/v2' if CLOWDER_API_VERSION == 'v2' else 'api'
 
 from pyclowder.extractors import Extractor
 import pyclowder.files
@@ -78,12 +85,17 @@ class Pdf2TextExtractor(Extractor):
             page_height = xml_surface_tags[0]['lry']
 
         # clean existing duplicate
+        connector.message_process(resource, "Check for duplicate files...")
         files_in_dataset = pyclowder.datasets.get_file_list(connector, host, secret_key, dataset_id)
         for file in files_in_dataset:
-            if file["filename"] == output_json_file or file["filename"] == output_xml_file:
-                url = '%sapi/files/%s?key=%s' % (host, file["id"], secret_key)
-                connector.delete(url, verify=connector.ssl_verify if connector else True)
-        connector.message_process(resource, "Check for duplicate files...")
+            if CLOWDER_API_VERSION == 'v2':
+                if file["name"] == output_json_file or file["name"] == output_xml_file:
+                    url = '%s%s/files/%s?key=%s' % (host, CLOWDER_API_PATH, file["id"], secret_key)
+                    connector.delete(url, verify=connector.ssl_verify if connector else True)
+            else:
+                if file["filename"] == output_json_file or file["filename"] == output_xml_file:
+                    url = '%s%s/files/%s?key=%s' % (host, CLOWDER_API_PATH, file["id"], secret_key)
+                    connector.delete(url, verify=connector.ssl_verify if connector else True)
 
         # upload to clowder
         connector.message_process(resource, "Uploading output files to Clowder...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tqdm
-pyclowder==2.7.0
+pyclowder==3.*
 beautifulsoup4==4.7.1
 boto3==1.9.147
 requests==2.21.0


### PR DESCRIPTION
Call Clowder v2 or Clowder v1 API depending on ENV variable CLOWDER_API_VERSION.

Upgraded from pyclowder 2.* to pyclowder 3.*.

Some original requests calls to API where replaced by pyclowder function to let pyclowder handle the clowder v1 / v2 differences.

*Have not tested this with Clowder v1, only v2.*